### PR TITLE
Substitui json por csv no dados extraídos

### DIFF
--- a/src/download_data.py
+++ b/src/download_data.py
@@ -85,6 +85,6 @@ if __name__ == "__main__":
         url = sys.argv[1]
     else:
         url = 'https://semsa.manaus.am.gov.br/' \
-              'sala-de-situacao/novo-coronavirus/'
+              'sala-de-situacao/novo-coronavirus/vacinas/'
     pdfDownloader = PdfDownloader(url)
     pdfDownloader.download()

--- a/src/extract_data.py
+++ b/src/extract_data.py
@@ -265,19 +265,15 @@ class PdfExtractor:
                 else:
                     table.pop(0)
 
-            data = []
             for record in table:
                 dictio = self.__get_dict(header, self.__remove_line_breaks(record))
                 self.__extra_attribs(dictio)
 
                 dictio['id'] = i
 
-                data.append(dictio)
-
                 i += 1
 
-                for entry in data:
-                    writer.writerow(entry)
+                writer.writerow(dictio)
 
             self.pdf.pages[page].flush_cache()
 

--- a/src/process_data.py
+++ b/src/process_data.py
@@ -22,7 +22,7 @@ def get_latest_filename():
 class DataProcessor:
 
     def __init__(self, input, output_path):
-        self.df = pd.read_json(input)
+        self.df = pd.read_csv(input)
         self.output_path = output_path
 
         self.df['vaccine_date'] = pd.to_datetime(self.df['vaccine_date'], format='%d/%m/%Y')


### PR DESCRIPTION
Para salvar os dados extraídos em json era necessário guardar os dados em memória, num dicionário.
Com csv podemos escrever diretamente no arquivo sem precisar guardar em memória.