### PR TITLE
fix: Atualiza url de download da lista de vacinados

### DIFF
--- a/src/download_data.py
+++ b/src/download_data.py
@@ -85,6 +85,6 @@ if __name__ == "__main__":
         url = sys.argv[1]
     else:
         url = 'https://semsa.manaus.am.gov.br/' \
-              'sala-de-situacao/novo-coronavirus/vacinas/'
+              'sala-de-situacao/novo-coronavirus/lista-de-vacinados-covid-19/'
     pdfDownloader = PdfDownloader(url)
     pdfDownloader.download()


### PR DESCRIPTION
Mudou o site de download

# Antigo
https://semsa.manaus.am.gov.br/sala-de-situacao/novo-coronavirus/vacinas/

# Novo
https://semsa.manaus.am.gov.br/sala-de-situacao/novo-coronavirus/lista-de-vacinados-covid-19/